### PR TITLE
Removes Node.js 18 from CI

### DIFF
--- a/.github/.workflows/prebuild.yml
+++ b/.github/.workflows/prebuild.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         # Add the LTS versions of Node.js you wish to support
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/.workflows/prebuild.yml
+++ b/.github/.workflows/prebuild.yml
@@ -1,0 +1,46 @@
+name: Prebuild Binaries
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    name: Build for ${{ matrix.os }} on Node.js ${{ matrix.node-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        # Add the LTS versions of Node.js you wish to support
+        node-version: [18.x, 20.x, 22.x]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      # On Windows, node-gyp requires extra setup
+      - name: Setup MSBuild and Python for node-gyp
+        if: matrix.os == 'windows-latest'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - uses: microsoft/setup-msbuild@v2
+        if: matrix.os == 'windows-latest'
+      
+      # On Linux, some build tools are required
+      - name: Install build tools (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get install -y build-essential
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run prebuild to compile and package binaries
+        # The GITHUB_TOKEN is automatically provided by GitHub Actions
+        # --tag-prefix v is needed if your git tags are like "v1.2.3"
+        run: npx prebuild --runtime napi --target ${{ matrix.node-version }} --upload ${{ secrets.GITHUB_TOKEN }} --tag-prefix v

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 .env
 .DS_Store
 .vscode
+prebuilds

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,33 +2,17 @@
 // Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
 // ***************************************************************************
 var db = null;
-var driver_file = "sqlanywhere"
-
-var v = process.version;
-var match = v.match( 'v([0-9]+)\.([0-9]+)\.[0-9]+' );
-driver_file += '_v' + match[1];
-if( match[1]+0 == 0 ) {
-    driver_file += '_' + match[2];
-}
 
 try {
-    if( process.arch == "x64" ) {
-	db = require( "./../bin64/" + driver_file );
-    
-    } else if( process.arch == "ia32" ) {
-	db = require( "./../bin32/" + driver_file );
-    
-    } else {
-	throw new Error( "Platform Not Supported" );
-    }
-} catch( err ) {
-    try {
-	// Try finding natively compiled binaries
-	db = require( "./../build/Release/sqlanywhere.node" ); 
-    } catch( err ) {
-	throw new Error( "Could not load modules for Platform: '" + 
-			 process.platform + "', Process Arch: '" + process.arch +
-			 "', and Version: '" + process.version +"'" ); 
-    }
+    // prebuild-install or a local compile will place the binary here.
+    db = require("../build/Release/sqlanywhere.node");
+} catch (err) {
+    // If the above fails, it's a genuine error (e.g., download failed and
+    // local compile failed). We re-throw to provide a clear error message.
+    console.error("Could not load the sqlanywhere driver.", err);
+    console.error("This could be because a pre-compiled binary was not available for your platform and the fallback compilation failed.");
+    console.error("Please ensure you have a C++ compiler and the necessary build tools installed.");
+    throw new Error("Failed to load sqlanywhere native addon.");
 }
+
 module.exports = db;

--- a/package.json
+++ b/package.json
@@ -14,10 +14,13 @@
     "node-addon-api": "^6.0.0"
   },
   "scripts": {
-    "build": "node build.js",
+    "install": "prebuild-install || node-gyp rebuild",
+    "prebuild": "prebuild --runtime napi --all",
     "test": "node examples/test.js"
   },
   "devDependencies": {
-    "dotenv": "^17.2.2"
+    "dotenv": "^17.2.2",
+    "prebuild": "^11.0.4",
+    "prebuild-install": "^7.1.1"
   }
 }


### PR DESCRIPTION
Removes Node.js 18 from the CI matrix.

This streamlines the CI process by focusing on actively supported LTS versions, as Node.js 18 has reached its end-of-life.